### PR TITLE
feat: import Grok quota cookies from Chrome on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Chrome notes:
 - macOS will prompt for the `Chrome Safe Storage` Keychain item on first refresh.
 - If refresh returns `chrome-tcc-denied`, grant Full Disk Access to **Hermes.app**
   (Desktop) and/or the Terminal you use for `hermes quota refresh`, then retry.
+- Chrome 127+ cookies prefix a SHA256(`host_key`) digest before the value; that prefix is stripped after AES-CBC decrypt.
 - Chrome App-Bound `v20` cookies are not supported (`chrome-app-bound`).
 - Safari is not supported.
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,30 @@ No network auth is performed; see `quota_providers/opencode_go.py`.
 
 ## Grok is opt-in
 
-Grok is the only provider read from your browser (Firefox `grok.com` cookies) —
-there is no clean API path right now. It is **disabled by default**. Turn it on:
+Grok is the only provider read from your browser — there is no clean API path
+right now. It is **disabled by default**. Turn it on:
 
 ```bash
 hermes config set plugins.entries.quota.settings.grokEnabled true
 hermes quota refresh
 ```
 
-When off, Grok simply reports `opt-in-disabled`. No cookies are read, no files written.
+When off, Grok reports `opt-in-disabled`. No cookies are read, no files written.
+
+Cookie sources, in order:
+
+1. `~/grok_session.json` if you created one yourself
+2. Firefox `grok.com` cookies
+3. Google Chrome `grok.com` cookies (macOS)
+
+Chrome notes:
+
+- Sign into https://grok.com in Chrome at least once.
+- macOS will prompt for the `Chrome Safe Storage` Keychain item on first refresh.
+- If refresh returns `chrome-tcc-denied`, grant Full Disk Access to **Hermes.app**
+  (Desktop) and/or the Terminal you use for `hermes quota refresh`, then retry.
+- Chrome App-Bound `v20` cookies are not supported (`chrome-app-bound`).
+- Safari is not supported.
 
 ## Install
 
@@ -107,6 +122,7 @@ the widget reads that file via `host.request('cli.exec', ['quota','status','--js
 
 - No telemetry. Cookies and tokens are never printed.
 - Grok cookies are used only for the Grok billing request, and only when you opt in.
+- Chrome/Firefox cookie values are never printed, cached, or written back to disk.
 - Missing credentials produce an explicit `unavailable` state — no fake zeros.
 - The plugin does not request permission to override built-in Hermes tools.
 
@@ -115,6 +131,8 @@ the widget reads that file via `host.request('cli.exec', ['quota','status','--js
 ```bash
 bash -n install.sh uninstall.sh
 python -m py_compile __init__.py commands.py quota_cache.py quota_providers/*.py
+python tests/test_fetchers.py
+python tests/test_browser_cookies.py
 node --check desktop/plugin.js
 hermes plugins doctor quota
 hermes quota refresh

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: quota
-version: 2.2.0
+version: 2.3.0
 description: "Per-provider quota / rate-limit status via /quota command and desktop widget. Reads precomputed quota_cache.json so the widget never does network I/O. Cherry-pick providers in Settings. Nous Portal works on free accounts; Gemini detects tier via loadCodeAssist; Grok uses the REST rate-limits endpoint. Pane detail: clean or dense."
 author: rarf
 kind: standalone

--- a/quota_providers/browser_cookies.py
+++ b/quota_providers/browser_cookies.py
@@ -8,6 +8,7 @@ leave this process.
 from __future__ import annotations
 
 import glob
+import hashlib
 import json
 import os
 import shutil
@@ -212,7 +213,29 @@ def _derive_chrome_key(password: str) -> bytes:
     ).derive(password.encode("utf-8"))
 
 
-def decrypt_chrome_cookie_value(key: bytes, blob: bytes) -> str:
+def _strip_chrome_host_hash(plaintext: bytes, host_key: Optional[str] = None) -> bytes:
+    """Chrome 127+ / cookie DB v24+ prefixes SHA256(host_key) before the value."""
+    if len(plaintext) < 32:
+        return plaintext
+    prefix, rest = plaintext[:32], plaintext[32:]
+    if host_key is not None:
+        expected = hashlib.sha256(host_key.encode("utf-8")).digest()
+        if prefix == expected:
+            return rest
+    try:
+        plaintext.decode("utf-8")
+        return plaintext
+    except UnicodeDecodeError:
+        try:
+            rest.decode("utf-8")
+            return rest
+        except UnicodeDecodeError:
+            return plaintext
+
+
+def decrypt_chrome_cookie_value(
+    key: bytes, blob: bytes, host_key: Optional[str] = None
+) -> str:
     if blob.startswith(b"v20"):
         raise ValueError("chrome-app-bound")
     if not blob.startswith((b"v10", b"v11")):
@@ -229,7 +252,11 @@ def decrypt_chrome_cookie_value(key: bytes, blob: bytes) -> str:
     pad = padded[-1]
     if pad < 1 or pad > 16 or padded[-pad:] != bytes([pad] * pad):
         raise ValueError("chrome-decrypt-failed")
-    return padded[:-pad].decode("utf-8")
+    plaintext = _strip_chrome_host_hash(padded[:-pad], host_key)
+    try:
+        return plaintext.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("chrome-decrypt-failed") from exc
 
 
 def _chrome_expires_ok(expires_utc: object, now: float) -> bool:
@@ -276,7 +303,7 @@ def load_chrome_grok_cookies() -> Optional[str]:
             try:
                 rows = conn.execute(
                     """
-                    SELECT name, encrypted_value, expires_utc
+                    SELECT name, host_key, encrypted_value, expires_utc
                     FROM cookies
                     WHERE host_key = 'grok.com' OR host_key LIKE '%.grok.com'
                     ORDER BY host_key, name
@@ -298,12 +325,12 @@ def load_chrome_grok_cookies() -> Optional[str]:
                     pass
 
         live_rows = []
-        for name, blob, expires_utc in rows:
+        for name, host_key, blob, expires_utc in rows:
             if not name or not _chrome_expires_ok(expires_utc, now):
                 continue
             if not isinstance(blob, (bytes, bytearray)):
                 continue
-            live_rows.append((str(name), bytes(blob)))
+            live_rows.append((str(name), str(host_key or ""), bytes(blob)))
         if not live_rows:
             continue
         saw_grok_rows = True
@@ -315,11 +342,11 @@ def load_chrome_grok_cookies() -> Optional[str]:
 
         pairs: list[str] = []
         seen: set[str] = set()
-        for name, blob in live_rows:
+        for name, host_key, blob in live_rows:
             if name in seen:
                 continue
             try:
-                value = decrypt_chrome_cookie_value(key, blob)
+                value = decrypt_chrome_cookie_value(key, blob, host_key=host_key)
             except ChromeCookieError:
                 raise
             except ValueError as exc:

--- a/quota_providers/browser_cookies.py
+++ b/quota_providers/browser_cookies.py
@@ -17,8 +17,9 @@ import subprocess
 import sys
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 
 class ChromeCookieError(Exception):
@@ -34,6 +35,35 @@ _CHROME_EPOCH_DELTA_S = 11_644_473_600
 _CHROME_KEY_SALT = b"saltysalt"
 _CHROME_KEY_ITERS = 1003
 _CHROME_CBC_IV = b" " * 16
+
+
+@contextmanager
+def _copied_sqlite(source: Path) -> Iterator[sqlite3.Connection]:
+    fd, temp_name = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        shutil.copyfile(source, temp_name)
+        conn = sqlite3.connect(temp_name)
+        try:
+            yield conn
+        finally:
+            conn.close()
+    finally:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+
+
+def _cookie_header(pairs: Iterator[tuple[str, str]]) -> Optional[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for name, value in pairs:
+        if not name or not value or name in seen:
+            continue
+        seen.add(name)
+        out.append(f"{name}={value}")
+    return "; ".join(out) if out else None
 
 
 def _firefox_cookie_dbs() -> list[Path]:
@@ -55,13 +85,8 @@ def _firefox_cookie_dbs() -> list[Path]:
 def load_firefox_grok_cookies() -> Optional[str]:
     now = int(time.time())
     for source in _firefox_cookie_dbs():
-        temp_name = None
         try:
-            with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as fh:
-                temp_name = fh.name
-            shutil.copy2(source, temp_name)
-            conn = sqlite3.connect(temp_name)
-            try:
+            with _copied_sqlite(source) as conn:
                 rows = conn.execute(
                     """
                     SELECT name, value
@@ -72,44 +97,33 @@ def load_firefox_grok_cookies() -> Optional[str]:
                     """,
                     (now,),
                 ).fetchall()
-            finally:
-                conn.close()
-            pairs = []
-            seen = set()
-            for name, value in rows:
-                if not name or name in seen:
-                    continue
-                seen.add(name)
-                pairs.append(f"{name}={value}")
-            if pairs:
-                return "; ".join(pairs)
         except (OSError, sqlite3.Error):
             continue
-        finally:
-            if temp_name:
-                try:
-                    os.unlink(temp_name)
-                except OSError:
-                    pass
+        header = _cookie_header((name, value) for name, value in rows)
+        if header:
+            return header
     return None
 
 
+def _is_tcc_error(exc: BaseException) -> bool:
+    if isinstance(exc, PermissionError):
+        return True
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) == 1:
+        return True
+    return "not permitted" in str(exc).lower()
+
+
 def _chrome_user_data_roots() -> list[Path]:
-    roots: list[Path] = []
-    home = Path.home()
-    roots.append(home / "Library" / "Application Support" / "Google" / "Chrome")
-    local = os.environ.get("LOCALAPPDATA")
-    if local:
-        roots.append(Path(local) / "Google" / "Chrome" / "User Data")
-    roots.append(home / ".config" / "google-chrome")
-    found: list[Path] = []
-    for path in roots:
-        try:
-            if path.exists():
-                found.append(path)
-        except OSError:
-            continue
-    return found
+    # Decrypt is macOS Keychain only. Do not scan Windows/Linux Chrome roots.
+    if sys.platform != "darwin":
+        return []
+    path = Path.home() / "Library" / "Application Support" / "Google" / "Chrome"
+    try:
+        return [path] if path.exists() else []
+    except OSError as exc:
+        if _is_tcc_error(exc):
+            raise ChromeCookieError("chrome-tcc-denied") from None
+        return []
 
 
 def _chrome_last_used_profile(root: Path) -> Optional[str]:
@@ -125,40 +139,73 @@ def _chrome_last_used_profile(root: Path) -> Optional[str]:
     return last if isinstance(last, str) and last else None
 
 
+def _safe_chrome_profile_dir(root: Path, name: str) -> Optional[Path]:
+    """Join a Local State / listing name only if it stays inside ``root``."""
+    if not name or name in {".", ".."} or "/" in name or "\\" in name:
+        return None
+    candidate = root / name
+    try:
+        candidate.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return None
+    try:
+        return candidate if candidate.is_dir() else None
+    except OSError as exc:
+        if _is_tcc_error(exc):
+            raise ChromeCookieError("chrome-tcc-denied") from None
+        return None
+
+
 def chrome_profile_dirs(root: Path) -> list[Path]:
     names: list[str] = []
     last = _chrome_last_used_profile(root)
     if last:
         names.append(last)
     names.append("Default")
+    saw_tcc = False
     try:
         extra = sorted(
             p.name
             for p in root.iterdir()
             if p.is_dir() and (p.name == "Default" or p.name.startswith("Profile "))
         )
-    except OSError:
-        extra = [f"Profile {i}" for i in range(1, 9)]
+    except OSError as exc:
+        extra = []
+        if _is_tcc_error(exc):
+            saw_tcc = True
     ordered: list[Path] = []
     seen = set()
     for name in names + extra:
         if name in seen:
             continue
         seen.add(name)
-        path = root / name
         try:
-            if path.is_dir():
-                ordered.append(path)
-        except OSError:
+            path = _safe_chrome_profile_dir(root, name)
+        except ChromeCookieError:
+            raise
+        except OSError as exc:
+            if _is_tcc_error(exc):
+                saw_tcc = True
             continue
+        if path is not None:
+            ordered.append(path)
+    if not ordered and saw_tcc:
+        raise ChromeCookieError("chrome-tcc-denied")
     return ordered
 
 
 def chrome_cookie_dbs() -> list[Path]:
     dbs: list[Path] = []
     seen: set[Path] = set()
+    saw_tcc = False
     for root in _chrome_user_data_roots():
-        for profile in chrome_profile_dirs(root):
+        try:
+            profiles = chrome_profile_dirs(root)
+        except OSError as exc:
+            if _is_tcc_error(exc):
+                saw_tcc = True
+            continue
+        for profile in profiles:
             for candidate in (
                 profile / "Network" / "Cookies",
                 profile / "Cookies",
@@ -167,8 +214,11 @@ def chrome_cookie_dbs() -> list[Path]:
                     if candidate.is_file() and candidate not in seen:
                         seen.add(candidate)
                         dbs.append(candidate)
-                except OSError:
-                    continue
+                except OSError as exc:
+                    if _is_tcc_error(exc):
+                        saw_tcc = True
+    if not dbs and saw_tcc:
+        raise ChromeCookieError("chrome-tcc-denied")
     return dbs
 
 
@@ -211,6 +261,13 @@ def _derive_chrome_key(password: str) -> bytes:
         salt=_CHROME_KEY_SALT,
         iterations=_CHROME_KEY_ITERS,
     ).derive(password.encode("utf-8"))
+
+
+def _chrome_aes_key() -> bytes:
+    password = _chrome_safe_storage_password()
+    if not password:
+        raise ChromeCookieError("chrome-keychain-denied")
+    return _derive_chrome_key(password)
 
 
 def _strip_chrome_host_hash(plaintext: bytes, host_key: Optional[str] = None) -> bytes:
@@ -272,81 +329,57 @@ def _chrome_expires_ok(expires_utc: object, now: float) -> bool:
     return unix > now
 
 
-def _is_tcc_error(exc: BaseException) -> bool:
-    if isinstance(exc, PermissionError):
-        return True
-    if isinstance(exc, OSError) and getattr(exc, "errno", None) == 1:
-        return True
-    return "not permitted" in str(exc).lower()
+def _chrome_expiry_cutoff(now: float) -> int:
+    return int((now + _CHROME_EPOCH_DELTA_S) * 1_000_000)
 
 
 def load_chrome_grok_cookies() -> Optional[str]:
+    if sys.platform != "darwin":
+        return None
     try:
         sources = chrome_cookie_dbs()
+    except ChromeCookieError:
+        raise
     except OSError as exc:
         if _is_tcc_error(exc):
             raise ChromeCookieError("chrome-tcc-denied") from None
         return None
 
     now = time.time()
-    saw_tcc = False
-    saw_grok_rows = False
+    cutoff = _chrome_expiry_cutoff(now)
+    key: Optional[bytes] = None
     decrypt_reason: Optional[str] = None
 
     for source in sources:
-        temp_name = None
         try:
-            with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as fh:
-                temp_name = fh.name
-            shutil.copy2(source, temp_name)
-            conn = sqlite3.connect(temp_name)
-            try:
+            with _copied_sqlite(source) as conn:
                 rows = conn.execute(
                     """
                     SELECT name, host_key, encrypted_value, expires_utc
                     FROM cookies
-                    WHERE host_key = 'grok.com' OR host_key LIKE '%.grok.com'
+                    WHERE (host_key = 'grok.com' OR host_key LIKE '%.grok.com')
+                      AND (expires_utc IS NULL OR expires_utc <= 0 OR expires_utc > ?)
                     ORDER BY host_key, name
-                    """
+                    """,
+                    (cutoff,),
                 ).fetchall()
-            finally:
-                conn.close()
         except OSError as exc:
             if _is_tcc_error(exc):
-                saw_tcc = True
+                raise ChromeCookieError("chrome-tcc-denied") from None
             continue
         except sqlite3.Error:
             continue
-        finally:
-            if temp_name:
-                try:
-                    os.unlink(temp_name)
-                except OSError:
-                    pass
 
-        live_rows = []
+        pairs: list[tuple[str, str]] = []
         for name, host_key, blob, expires_utc in rows:
             if not name or not _chrome_expires_ok(expires_utc, now):
                 continue
             if not isinstance(blob, (bytes, bytearray)):
                 continue
-            live_rows.append((str(name), str(host_key or ""), bytes(blob)))
-        if not live_rows:
-            continue
-        saw_grok_rows = True
-
-        password = _chrome_safe_storage_password()
-        if not password:
-            raise ChromeCookieError("chrome-keychain-denied")
-        key = _derive_chrome_key(password)
-
-        pairs: list[str] = []
-        seen: set[str] = set()
-        for name, host_key, blob in live_rows:
-            if name in seen:
-                continue
+            if key is None:
+                key = _chrome_aes_key()
             try:
-                value = decrypt_chrome_cookie_value(key, blob, host_key=host_key)
+                value = decrypt_chrome_cookie_value(key, bytes(blob), host_key=str(host_key or ""))
             except ChromeCookieError:
                 raise
             except ValueError as exc:
@@ -354,26 +387,13 @@ def load_chrome_grok_cookies() -> Optional[str]:
                 decrypt_reason = reason
                 continue
             except Exception:
-                decrypt_reason = "chrome-decrypt-failed"
-                continue
-            if not value:
-                continue
-            seen.add(name)
-            pairs.append(f"{name}={value}")
-        if pairs:
-            return "; ".join(pairs)
+                raise ChromeCookieError("chrome-decrypt-failed") from None
+            if value:
+                pairs.append((str(name), value))
+        header = _cookie_header(iter(pairs))
+        if header:
+            return header
 
     if decrypt_reason:
         raise ChromeCookieError(decrypt_reason)
-    if saw_tcc and not saw_grok_rows:
-        raise ChromeCookieError("chrome-tcc-denied")
-    if not sources:
-        roots = _chrome_user_data_roots()
-        if roots:
-            probe = roots[0] / "Default" / "Cookies"
-            try:
-                probe.open("rb").close()
-            except OSError as exc:
-                if _is_tcc_error(exc):
-                    raise ChromeCookieError("chrome-tcc-denied") from None
     return None

--- a/quota_providers/browser_cookies.py
+++ b/quota_providers/browser_cookies.py
@@ -1,19 +1,38 @@
 """Local browser-cookie helpers for the Grok quota provider.
 
-Firefox stores cookies in cookies.sqlite. We copy the database first because
-Firefox may keep the live file locked. Only grok.com domains are selected and
-cookie values never leave this process.
+Firefox stores cookies in cookies.sqlite. Chrome stores them encrypted in
+Cookies SQLite. We copy each database first because the live browser may keep
+the file locked. Only grok.com domains are selected and cookie values never
+leave this process.
 """
 from __future__ import annotations
 
 import glob
+import json
 import os
 import shutil
 import sqlite3
+import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
 from typing import Optional
+
+
+class ChromeCookieError(Exception):
+    """Typed Chrome import failure. ``reason`` is a kebab-case unavailable_reason."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+# Chrome expires_utc is microseconds since 1601-01-01 UTC.
+_CHROME_EPOCH_DELTA_S = 11_644_473_600
+_CHROME_KEY_SALT = b"saltysalt"
+_CHROME_KEY_ITERS = 1003
+_CHROME_CBC_IV = b" " * 16
 
 
 def _firefox_cookie_dbs() -> list[Path]:
@@ -71,4 +90,263 @@ def load_firefox_grok_cookies() -> Optional[str]:
                     os.unlink(temp_name)
                 except OSError:
                     pass
+    return None
+
+
+def _chrome_user_data_roots() -> list[Path]:
+    roots: list[Path] = []
+    home = Path.home()
+    roots.append(home / "Library" / "Application Support" / "Google" / "Chrome")
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        roots.append(Path(local) / "Google" / "Chrome" / "User Data")
+    roots.append(home / ".config" / "google-chrome")
+    found: list[Path] = []
+    for path in roots:
+        try:
+            if path.exists():
+                found.append(path)
+        except OSError:
+            continue
+    return found
+
+
+def _chrome_last_used_profile(root: Path) -> Optional[str]:
+    local_state = root / "Local State"
+    try:
+        data = json.loads(local_state.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError):
+        return None
+    profile = data.get("profile") if isinstance(data, dict) else None
+    if not isinstance(profile, dict):
+        return None
+    last = profile.get("last_used") or profile.get("last_used_profile_directory")
+    return last if isinstance(last, str) and last else None
+
+
+def chrome_profile_dirs(root: Path) -> list[Path]:
+    names: list[str] = []
+    last = _chrome_last_used_profile(root)
+    if last:
+        names.append(last)
+    names.append("Default")
+    try:
+        extra = sorted(
+            p.name
+            for p in root.iterdir()
+            if p.is_dir() and (p.name == "Default" or p.name.startswith("Profile "))
+        )
+    except OSError:
+        extra = [f"Profile {i}" for i in range(1, 9)]
+    ordered: list[Path] = []
+    seen = set()
+    for name in names + extra:
+        if name in seen:
+            continue
+        seen.add(name)
+        path = root / name
+        try:
+            if path.is_dir():
+                ordered.append(path)
+        except OSError:
+            continue
+    return ordered
+
+
+def chrome_cookie_dbs() -> list[Path]:
+    dbs: list[Path] = []
+    seen: set[Path] = set()
+    for root in _chrome_user_data_roots():
+        for profile in chrome_profile_dirs(root):
+            for candidate in (
+                profile / "Network" / "Cookies",
+                profile / "Cookies",
+            ):
+                try:
+                    if candidate.is_file() and candidate not in seen:
+                        seen.add(candidate)
+                        dbs.append(candidate)
+                except OSError:
+                    continue
+    return dbs
+
+
+def _chrome_safe_storage_password() -> Optional[str]:
+    if sys.platform != "darwin":
+        return None
+    try:
+        completed = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-w",
+                "-s",
+                "Chrome Safe Storage",
+                "-a",
+                "Chrome",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    password = (completed.stdout or "").strip()
+    return password or None
+
+
+def _derive_chrome_key(password: str) -> bytes:
+    try:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    except ImportError:
+        raise ChromeCookieError("chrome-crypto-missing") from None
+    return PBKDF2HMAC(
+        algorithm=hashes.SHA1(),
+        length=16,
+        salt=_CHROME_KEY_SALT,
+        iterations=_CHROME_KEY_ITERS,
+    ).derive(password.encode("utf-8"))
+
+
+def decrypt_chrome_cookie_value(key: bytes, blob: bytes) -> str:
+    if blob.startswith(b"v20"):
+        raise ValueError("chrome-app-bound")
+    if not blob.startswith((b"v10", b"v11")):
+        raise ValueError("chrome-unknown-prefix")
+    try:
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    except ImportError:
+        raise ChromeCookieError("chrome-crypto-missing") from None
+    ciphertext = blob[3:]
+    decryptor = Cipher(algorithms.AES(key), modes.CBC(_CHROME_CBC_IV)).decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+    if not padded:
+        raise ValueError("chrome-decrypt-failed")
+    pad = padded[-1]
+    if pad < 1 or pad > 16 or padded[-pad:] != bytes([pad] * pad):
+        raise ValueError("chrome-decrypt-failed")
+    return padded[:-pad].decode("utf-8")
+
+
+def _chrome_expires_ok(expires_utc: object, now: float) -> bool:
+    if expires_utc in (None, 0):
+        return True
+    try:
+        expiry = int(str(expires_utc))
+    except (TypeError, ValueError):
+        return False
+    if expiry <= 0:
+        return True
+    unix = (expiry / 1_000_000) - _CHROME_EPOCH_DELTA_S
+    return unix > now
+
+
+def _is_tcc_error(exc: BaseException) -> bool:
+    if isinstance(exc, PermissionError):
+        return True
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) == 1:
+        return True
+    return "not permitted" in str(exc).lower()
+
+
+def load_chrome_grok_cookies() -> Optional[str]:
+    try:
+        sources = chrome_cookie_dbs()
+    except OSError as exc:
+        if _is_tcc_error(exc):
+            raise ChromeCookieError("chrome-tcc-denied") from None
+        return None
+
+    now = time.time()
+    saw_tcc = False
+    saw_grok_rows = False
+    decrypt_reason: Optional[str] = None
+
+    for source in sources:
+        temp_name = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as fh:
+                temp_name = fh.name
+            shutil.copy2(source, temp_name)
+            conn = sqlite3.connect(temp_name)
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT name, encrypted_value, expires_utc
+                    FROM cookies
+                    WHERE host_key = 'grok.com' OR host_key LIKE '%.grok.com'
+                    ORDER BY host_key, name
+                    """
+                ).fetchall()
+            finally:
+                conn.close()
+        except OSError as exc:
+            if _is_tcc_error(exc):
+                saw_tcc = True
+            continue
+        except sqlite3.Error:
+            continue
+        finally:
+            if temp_name:
+                try:
+                    os.unlink(temp_name)
+                except OSError:
+                    pass
+
+        live_rows = []
+        for name, blob, expires_utc in rows:
+            if not name or not _chrome_expires_ok(expires_utc, now):
+                continue
+            if not isinstance(blob, (bytes, bytearray)):
+                continue
+            live_rows.append((str(name), bytes(blob)))
+        if not live_rows:
+            continue
+        saw_grok_rows = True
+
+        password = _chrome_safe_storage_password()
+        if not password:
+            raise ChromeCookieError("chrome-keychain-denied")
+        key = _derive_chrome_key(password)
+
+        pairs: list[str] = []
+        seen: set[str] = set()
+        for name, blob in live_rows:
+            if name in seen:
+                continue
+            try:
+                value = decrypt_chrome_cookie_value(key, blob)
+            except ChromeCookieError:
+                raise
+            except ValueError as exc:
+                reason = str(exc) if str(exc).startswith("chrome-") else "chrome-decrypt-failed"
+                decrypt_reason = reason
+                continue
+            except Exception:
+                decrypt_reason = "chrome-decrypt-failed"
+                continue
+            if not value:
+                continue
+            seen.add(name)
+            pairs.append(f"{name}={value}")
+        if pairs:
+            return "; ".join(pairs)
+
+    if decrypt_reason:
+        raise ChromeCookieError(decrypt_reason)
+    if saw_tcc and not saw_grok_rows:
+        raise ChromeCookieError("chrome-tcc-denied")
+    if not sources:
+        roots = _chrome_user_data_roots()
+        if roots:
+            probe = roots[0] / "Default" / "Cookies"
+            try:
+                probe.open("rb").close()
+            except OSError as exc:
+                if _is_tcc_error(exc):
+                    raise ChromeCookieError("chrome-tcc-denied") from None
     return None

--- a/quota_providers/grok.py
+++ b/quota_providers/grok.py
@@ -11,7 +11,11 @@ import urllib.error
 from typing import Optional
 
 from .base import QuotaResult, QuotaWindow, build_unavailable
-from .browser_cookies import load_firefox_grok_cookies
+from .browser_cookies import (
+    ChromeCookieError,
+    load_chrome_grok_cookies,
+    load_firefox_grok_cookies,
+)
 
 _GROK_ENDPOINT = "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"
 _REST_RATELIMITS_URL = "https://grok.com/rest/rate-limits"
@@ -61,9 +65,12 @@ def _load_cookies() -> Optional[str]:
     except Exception:
         pass
 
-    # Automatic local fallback for the logged-in Firefox profile. The helper
-    # copies the SQLite DB before reading it and only selects grok.com cookies.
-    return load_firefox_grok_cookies()
+    # Automatic local fallback: Firefox first (plaintext cookies), then
+    # Chrome (encrypted). Only grok.com cookies are selected.
+    firefox = load_firefox_grok_cookies()
+    if firefox:
+        return firefox
+    return load_chrome_grok_cookies()
 
 
 def _parse_grok_protobuf(raw: bytes) -> Optional[QuotaResult]:
@@ -287,7 +294,10 @@ def _fetch_grok_rest(cookies: str) -> Optional[QuotaResult]:
 
 
 def fetch_grok_quota() -> QuotaResult:
-    cookies = _load_cookies()
+    try:
+        cookies = _load_cookies()
+    except ChromeCookieError as exc:
+        return build_unavailable("grok", exc.reason)
     if not cookies:
         return build_unavailable("grok", "no-session-cookies")
 
@@ -336,8 +346,8 @@ def fetch_grok_quota() -> QuotaResult:
 
 from .registry import register as _register  # noqa: E402
 
-# Grok is opt-in: reads browser cookies (Firefox grok.com), which is the only
-# path we have right now and is sensitive. Disabled by default; enable with:
+# Grok is opt-in: reads browser cookies (Firefox grok.com, then Chrome on
+# macOS). Disabled by default; enable with:
 #   hermes config set plugins.entries.quota.settings.grokEnabled true
 import os as _os
 

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -1,0 +1,264 @@
+"""Offline unit tests for Chrome grok.com cookie import.
+
+Run from the repo root:  python tests/test_browser_cookies.py
+No live browser profile, Keychain, or network is touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+    _HAS_CRYPTO = True
+except ImportError:  # pragma: no cover - environment-dependent
+    _HAS_CRYPTO = False
+
+_TEST_PASSWORD = "test-chrome-safe-storage"
+_FUTURE_EXPIRES = 20_000_000_000_000_000  # Chrome epoch, far future
+_EXPIRED_EXPIRES = 1
+
+
+def _pbkdf2_key(password: bytes) -> bytes:
+    return PBKDF2HMAC(
+        algorithm=hashes.SHA1(), length=16, salt=b"saltysalt", iterations=1003
+    ).derive(password)
+
+
+def _encrypt_v10(key: bytes, plaintext: str) -> bytes:
+    data = plaintext.encode("utf-8")
+    pad = 16 - (len(data) % 16)
+    data = data + bytes([pad] * pad)
+    encryptor = Cipher(algorithms.AES(key), modes.CBC(b" " * 16)).encryptor()
+    return b"v10" + encryptor.update(data) + encryptor.finalize()
+
+
+def _write_cookies_db(path: Path, rows: list[tuple[str, str, bytes, int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE cookies "
+            "(host_key TEXT, name TEXT, encrypted_value BLOB, expires_utc INTEGER)"
+        )
+        conn.executemany(
+            "INSERT INTO cookies (host_key, name, encrypted_value, expires_utc) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class ChromeDiscoveryTests(unittest.TestCase):
+    def test_prefers_network_cookies_then_legacy(self):
+        from quota_providers import browser_cookies as bc
+
+        with self._temp_chrome() as root:
+            last = root / "Profile 2"
+            (last / "Network").mkdir(parents=True)
+            (last / "Network" / "Cookies").write_bytes(b"")
+            (root / "Default").mkdir()
+            (root / "Default" / "Cookies").write_bytes(b"")
+            (root / "Local State").write_text(
+                json.dumps({"profile": {"last_used": "Profile 2"}}),
+                encoding="utf-8",
+            )
+            with mock.patch.object(bc, "_chrome_user_data_roots", return_value=[root]):
+                dbs = bc.chrome_cookie_dbs()
+        self.assertEqual(dbs[0], last / "Network" / "Cookies")
+        self.assertIn(root / "Default" / "Cookies", dbs)
+
+    def test_skips_missing_last_used_profile(self):
+        from quota_providers import browser_cookies as bc
+
+        with self._temp_chrome() as root:
+            (root / "Default").mkdir()
+            (root / "Default" / "Cookies").write_bytes(b"")
+            (root / "Local State").write_text(
+                json.dumps({"profile": {"last_used": "Person 1"}}),
+                encoding="utf-8",
+            )
+            with mock.patch.object(bc, "_chrome_user_data_roots", return_value=[root]):
+                dirs = bc.chrome_profile_dirs(root)
+        self.assertEqual(dirs[0].name, "Default")
+
+    def _temp_chrome(self):
+        import tempfile
+
+        class _Ctx:
+            def __enter__(self_inner):
+                self_inner._tmp = tempfile.TemporaryDirectory()
+                root = Path(self_inner._tmp.name) / "Chrome"
+                root.mkdir()
+                return root
+
+            def __exit__(self_inner, *exc):
+                self_inner._tmp.cleanup()
+                return False
+
+        return _Ctx()
+
+
+@unittest.skipUnless(_HAS_CRYPTO, "cryptography is required for Chrome decrypt tests")
+class ChromeDecryptTests(unittest.TestCase):
+    def test_decrypts_v10_cookie(self):
+        from quota_providers.browser_cookies import decrypt_chrome_cookie_value
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        blob = _encrypt_v10(key, "s3cret-value")
+        self.assertEqual(decrypt_chrome_cookie_value(key, blob), "s3cret-value")
+
+    def test_rejects_v20_prefix(self):
+        from quota_providers.browser_cookies import decrypt_chrome_cookie_value
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        with self.assertRaises(ValueError) as ctx:
+            decrypt_chrome_cookie_value(key, b"v20" + b"\x00" * 32)
+        msg = str(ctx.exception).lower()
+        self.assertTrue("v20" in msg or "app-bound" in msg)
+
+
+@unittest.skipUnless(_HAS_CRYPTO, "cryptography is required for Chrome decrypt tests")
+class ChromeLoaderTests(unittest.TestCase):
+    def test_selects_only_unexpired_grok_hosts(self):
+        from quota_providers import browser_cookies as bc
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        with self._db() as db:
+            _write_cookies_db(
+                db,
+                [
+                    (".grok.com", "sso", _encrypt_v10(key, "alpha"), _FUTURE_EXPIRES),
+                    ("accounts.google.com", "SID", _encrypt_v10(key, "nope"), _FUTURE_EXPIRES),
+                    ("grok.com", "stale", _encrypt_v10(key, "old"), _EXPIRED_EXPIRES),
+                ],
+            )
+            with mock.patch.object(bc, "chrome_cookie_dbs", return_value=[db]), mock.patch.object(
+                bc, "_chrome_safe_storage_password", return_value=_TEST_PASSWORD
+            ):
+                header = bc.load_chrome_grok_cookies()
+        self.assertEqual(header, "sso=alpha")
+        self.assertNotIn("nope", header)
+        self.assertNotIn("SID", header)
+        self.assertNotIn("stale", header)
+        self.assertNotIn("old", header)
+
+    def test_keeps_session_cookies_with_zero_expiry(self):
+        from quota_providers import browser_cookies as bc
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        with self._db() as db:
+            _write_cookies_db(
+                db,
+                [("grok.com", "sid", _encrypt_v10(key, "session"), 0)],
+            )
+            with mock.patch.object(bc, "chrome_cookie_dbs", return_value=[db]), mock.patch.object(
+                bc, "_chrome_safe_storage_password", return_value=_TEST_PASSWORD
+            ):
+                header = bc.load_chrome_grok_cookies()
+        self.assertEqual(header, "sid=session")
+
+    def test_missing_keychain_is_typed_error(self):
+        from quota_providers import browser_cookies as bc
+        from quota_providers.browser_cookies import ChromeCookieError
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        with self._db() as db:
+            _write_cookies_db(
+                db,
+                [("grok.com", "sso", _encrypt_v10(key, "alpha"), _FUTURE_EXPIRES)],
+            )
+            with mock.patch.object(bc, "chrome_cookie_dbs", return_value=[db]), mock.patch.object(
+                bc, "_chrome_safe_storage_password", return_value=None
+            ):
+                with self.assertRaises(ChromeCookieError) as ctx:
+                    bc.load_chrome_grok_cookies()
+        self.assertEqual(ctx.exception.reason, "chrome-keychain-denied")
+
+    def test_v20_blob_is_app_bound(self):
+        from quota_providers import browser_cookies as bc
+        from quota_providers.browser_cookies import ChromeCookieError
+
+        with self._db() as db:
+            _write_cookies_db(
+                db,
+                [("grok.com", "sso", b"v20" + b"\x00" * 32, _FUTURE_EXPIRES)],
+            )
+            with mock.patch.object(bc, "chrome_cookie_dbs", return_value=[db]), mock.patch.object(
+                bc, "_chrome_safe_storage_password", return_value=_TEST_PASSWORD
+            ):
+                with self.assertRaises(ChromeCookieError) as ctx:
+                    bc.load_chrome_grok_cookies()
+        self.assertEqual(ctx.exception.reason, "chrome-app-bound")
+
+    def test_permission_error_is_tcc_denied(self):
+        from quota_providers import browser_cookies as bc
+        from quota_providers.browser_cookies import ChromeCookieError
+
+        with mock.patch.object(
+            bc, "chrome_cookie_dbs", side_effect=PermissionError("Operation not permitted")
+        ):
+            with self.assertRaises(ChromeCookieError) as ctx:
+                bc.load_chrome_grok_cookies()
+        self.assertEqual(ctx.exception.reason, "chrome-tcc-denied")
+
+    def _db(self):
+        import tempfile
+
+        class _Ctx:
+            def __enter__(self_inner):
+                self_inner._tmp = tempfile.TemporaryDirectory()
+                return Path(self_inner._tmp.name) / "Cookies"
+
+            def __exit__(self_inner, *exc):
+                self_inner._tmp.cleanup()
+                return False
+
+        return _Ctx()
+
+
+class GrokChromeWireTests(unittest.TestCase):
+    def test_fetch_maps_tcc_to_unavailable(self):
+        from quota_providers import grok
+        from quota_providers.browser_cookies import ChromeCookieError
+
+        with mock.patch.object(grok, "_SESSION_PATH", "/tmp/missing-grok-session.json"), mock.patch.object(
+            grok, "load_firefox_grok_cookies", return_value=None
+        ), mock.patch.object(
+            grok,
+            "load_chrome_grok_cookies",
+            side_effect=ChromeCookieError("chrome-tcc-denied"),
+        ):
+            res = grok.fetch_grok_quota()
+        self.assertEqual(res.unavailable_reason, "chrome-tcc-denied")
+        self.assertEqual(res.windows, [])
+
+    def test_firefox_still_wins_over_chrome(self):
+        from quota_providers import grok
+
+        with mock.patch.object(grok, "_SESSION_PATH", "/tmp/missing-grok-session.json"), mock.patch.object(
+            grok, "load_firefox_grok_cookies", return_value="ff=1"
+        ), mock.patch.object(
+            grok, "load_chrome_grok_cookies", side_effect=AssertionError("chrome should not run")
+        ):
+            cookies = grok._load_cookies()
+        self.assertEqual(cookies, "ff=1")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -92,6 +92,39 @@ class ChromeDiscoveryTests(unittest.TestCase):
         self.assertEqual(dbs[0], last / "Network" / "Cookies")
         self.assertIn(root / "Default" / "Cookies", dbs)
 
+    def test_does_not_invent_profile_dirs_when_listing_fails(self):
+        from quota_providers import browser_cookies as bc
+
+        with self._temp_chrome() as root:
+            (root / "Default").mkdir()
+            with mock.patch.object(Path, "iterdir", side_effect=PermissionError("denied")):
+                dirs = bc.chrome_profile_dirs(root)
+        self.assertEqual([p.name for p in dirs], ["Default"])
+
+    def test_rejects_traversing_last_used_profile(self):
+        from quota_providers import browser_cookies as bc
+
+        with self._temp_chrome() as root:
+            (root / "Default").mkdir()
+            (root / "Local State").write_text(
+                json.dumps({"profile": {"last_used": "../outside"}}),
+                encoding="utf-8",
+            )
+            dirs = bc.chrome_profile_dirs(root)
+        self.assertEqual([p.name for p in dirs], ["Default"])
+
+    def test_listing_tcc_without_profiles_is_typed_error(self):
+        from quota_providers import browser_cookies as bc
+        from quota_providers.browser_cookies import ChromeCookieError
+
+        with self._temp_chrome() as root:
+            with mock.patch.object(
+                Path, "iterdir", side_effect=PermissionError("Operation not permitted")
+            ):
+                with self.assertRaises(ChromeCookieError) as ctx:
+                    bc.chrome_profile_dirs(root)
+        self.assertEqual(ctx.exception.reason, "chrome-tcc-denied")
+
     def test_skips_missing_last_used_profile(self):
         from quota_providers import browser_cookies as bc
 

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -6,6 +6,7 @@ No live browser profile, Keychain, or network is touched.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -38,12 +39,20 @@ def _pbkdf2_key(password: bytes) -> bytes:
     ).derive(password)
 
 
-def _encrypt_v10(key: bytes, plaintext: str) -> bytes:
-    data = plaintext.encode("utf-8")
+def _encrypt_v10_bytes(key: bytes, data: bytes) -> bytes:
     pad = 16 - (len(data) % 16)
     data = data + bytes([pad] * pad)
     encryptor = Cipher(algorithms.AES(key), modes.CBC(b" " * 16)).encryptor()
     return b"v10" + encryptor.update(data) + encryptor.finalize()
+
+
+def _encrypt_v10(key: bytes, plaintext: str) -> bytes:
+    return _encrypt_v10_bytes(key, plaintext.encode("utf-8"))
+
+
+def _encrypt_v10_host_hash(key: bytes, host_key: str, plaintext: str) -> bytes:
+    payload = hashlib.sha256(host_key.encode("utf-8")).digest() + plaintext.encode("utf-8")
+    return _encrypt_v10_bytes(key, payload)
 
 
 def _write_cookies_db(path: Path, rows: list[tuple[str, str, bytes, int]]) -> None:
@@ -132,6 +141,25 @@ class ChromeDecryptTests(unittest.TestCase):
         msg = str(ctx.exception).lower()
         self.assertTrue("v20" in msg or "app-bound" in msg)
 
+    def test_strips_chrome127_host_hash_prefix(self):
+        from quota_providers.browser_cookies import decrypt_chrome_cookie_value
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        host = ".grok.com"
+        blob = _encrypt_v10_host_hash(key, host, "s3cret-value")
+        self.assertEqual(
+            decrypt_chrome_cookie_value(key, blob, host_key=host), "s3cret-value"
+        )
+
+    def test_legacy_plaintext_still_works_with_host_key(self):
+        from quota_providers.browser_cookies import decrypt_chrome_cookie_value
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        blob = _encrypt_v10(key, "s3cret-value")
+        self.assertEqual(
+            decrypt_chrome_cookie_value(key, blob, host_key=".grok.com"), "s3cret-value"
+        )
+
 
 @unittest.skipUnless(_HAS_CRYPTO, "cryptography is required for Chrome decrypt tests")
 class ChromeLoaderTests(unittest.TestCase):
@@ -157,6 +185,28 @@ class ChromeLoaderTests(unittest.TestCase):
         self.assertNotIn("SID", header)
         self.assertNotIn("stale", header)
         self.assertNotIn("old", header)
+
+    def test_decrypts_chrome127_host_hash_prefixed_cookies(self):
+        from quota_providers import browser_cookies as bc
+
+        key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
+        with self._db() as db:
+            _write_cookies_db(
+                db,
+                [
+                    (
+                        ".grok.com",
+                        "sso",
+                        _encrypt_v10_host_hash(key, ".grok.com", "alpha"),
+                        _FUTURE_EXPIRES,
+                    )
+                ],
+            )
+            with mock.patch.object(bc, "chrome_cookie_dbs", return_value=[db]), mock.patch.object(
+                bc, "_chrome_safe_storage_password", return_value=_TEST_PASSWORD
+            ):
+                header = bc.load_chrome_grok_cookies()
+        self.assertEqual(header, "sso=alpha")
 
     def test_keeps_session_cookies_with_zero_expiry(self):
         from quota_providers import browser_cookies as bc


### PR DESCRIPTION
## Summary

- Add opt-in macOS Chrome support for Grok quota cookies (`v10` / `v11` via Keychain `Chrome Safe Storage`).
- Keep the existing source order: `~/grok_session.json` → Firefox → Chrome.
- Fail open with typed reasons (`chrome-tcc-denied`, `chrome-keychain-denied`, `chrome-app-bound`, `chrome-decrypt-failed`) instead of crashing refresh.
- Strip the Chrome 127+ / cookie-DB v24 `SHA256(host_key)` prefix after AES-CBC decrypt.
- Cookie values are never printed, cached, or written back to disk.

## Why

Grok stays opt-in (`plugins.entries.quota.settings.grokEnabled`). Firefox is no longer required for people who only sign into grok.com in Chrome.

## Testing

```bash
python tests/test_browser_cookies.py
PYTHONPATH=. python tests/test_fetchers.py
PYTHONPATH=. python tests/test_opencode_go.py
```

Live check after Full Disk Access: `hermes quota refresh` returned Weekly / Grok Build windows. Cookie values were not logged.

## Scope

- macOS Chrome only. Safari, Windows, Linux Chrome, and App-Bound `v20` cookies are out of scope.
- No installer-script repair from older local checkouts.
