### PR TITLE
review: collapse dual error channel into typed ChromeCookieError

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Chrome notes:
   (Desktop) and/or the Terminal you use for `hermes quota refresh`, then retry.
 - Chrome 127+ cookies prefix a SHA256(`host_key`) digest before the value; that prefix is stripped after AES-CBC decrypt.
 - Chrome App-Bound `v20` cookies are not supported (`chrome-app-bound`).
+- Typed failure reasons surfaced by refresh: `chrome-tcc-denied`,
+  `chrome-keychain-denied`, `chrome-app-bound`, `chrome-unknown-prefix`
+  (unrecognized cookie format), `chrome-decrypt-failed`, and
+  `chrome-crypto-missing` (install the `cryptography` package).
 - Safari is not supported.
 
 ## Install

--- a/quota_providers/browser_cookies.py
+++ b/quota_providers/browser_cookies.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import glob
 import hashlib
 import json
+import logging
 import os
 import shutil
 import sqlite3
@@ -19,15 +20,46 @@ import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Iterator, NoReturn, Optional
+
+try:
+    import cryptography  # noqa: F401  # dependency probe
+
+    _HAS_CRYPTO = True
+except ImportError:  # pragma: no cover - environment-dependent
+    _HAS_CRYPTO = False
+
+logger = logging.getLogger(__name__)
+
+# Typed failures that must abort the whole Chrome import instead of
+# degrading to the next profile database.
+_HARD_CHROME_FAILURES = frozenset({"chrome-crypto-missing"})
 
 
-class ChromeCookieError(Exception):
-    """Typed Chrome import failure. ``reason`` is a kebab-case unavailable_reason."""
+class ChromeCookieError(ValueError):
+    """Typed Chrome import failure.
+
+    Subclasses ``ValueError`` so the decrypt primitive can raise typed
+    failures directly (no string re-parsing at the call site), while any
+    unexpected ``ValueError`` still degrades to ``chrome-decrypt-failed``.
+    """
 
     def __init__(self, reason: str):
         super().__init__(reason)
         self.reason = reason
+
+
+def _raise_chrome_tcc() -> NoReturn:
+    """Single spelling of the typed TCC-denied failure."""
+    raise ChromeCookieError("chrome-tcc-denied") from None
+
+
+def _is_tcc_error(exc: BaseException) -> bool:
+    if isinstance(exc, PermissionError):
+        return True
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) == 1:
+        return True
+    return "not permitted" in str(exc).lower()
 
 
 # Chrome expires_utc is microseconds since 1601-01-01 UTC.
@@ -105,14 +137,6 @@ def load_firefox_grok_cookies() -> Optional[str]:
     return None
 
 
-def _is_tcc_error(exc: BaseException) -> bool:
-    if isinstance(exc, PermissionError):
-        return True
-    if isinstance(exc, OSError) and getattr(exc, "errno", None) == 1:
-        return True
-    return "not permitted" in str(exc).lower()
-
-
 def _chrome_user_data_roots() -> list[Path]:
     # Decrypt is macOS Keychain only. Do not scan Windows/Linux Chrome roots.
     if sys.platform != "darwin":
@@ -122,7 +146,7 @@ def _chrome_user_data_roots() -> list[Path]:
         return [path] if path.exists() else []
     except OSError as exc:
         if _is_tcc_error(exc):
-            raise ChromeCookieError("chrome-tcc-denied") from None
+            _raise_chrome_tcc()
         return []
 
 
@@ -152,7 +176,7 @@ def _safe_chrome_profile_dir(root: Path, name: str) -> Optional[Path]:
         return candidate if candidate.is_dir() else None
     except OSError as exc:
         if _is_tcc_error(exc):
-            raise ChromeCookieError("chrome-tcc-denied") from None
+            _raise_chrome_tcc()
         return None
 
 
@@ -190,7 +214,7 @@ def chrome_profile_dirs(root: Path) -> list[Path]:
         if path is not None:
             ordered.append(path)
     if not ordered and saw_tcc:
-        raise ChromeCookieError("chrome-tcc-denied")
+        _raise_chrome_tcc()
     return ordered
 
 
@@ -218,7 +242,7 @@ def chrome_cookie_dbs() -> list[Path]:
                     if _is_tcc_error(exc):
                         saw_tcc = True
     if not dbs and saw_tcc:
-        raise ChromeCookieError("chrome-tcc-denied")
+        _raise_chrome_tcc()
     return dbs
 
 
@@ -250,11 +274,11 @@ def _chrome_safe_storage_password() -> Optional[str]:
 
 
 def _derive_chrome_key(password: str) -> bytes:
-    try:
-        from cryptography.hazmat.primitives import hashes
-        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-    except ImportError:
-        raise ChromeCookieError("chrome-crypto-missing") from None
+    if not _HAS_CRYPTO:
+        raise ChromeCookieError("chrome-crypto-missing")
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
     return PBKDF2HMAC(
         algorithm=hashes.SHA1(),
         length=16,
@@ -293,27 +317,33 @@ def _strip_chrome_host_hash(plaintext: bytes, host_key: Optional[str] = None) ->
 def decrypt_chrome_cookie_value(
     key: bytes, blob: bytes, host_key: Optional[str] = None
 ) -> str:
+    """Decrypt one Chrome cookie value.
+
+    Raises ``ChromeCookieError`` with a kebab-case reason for every typed
+    failure (``chrome-app-bound``, ``chrome-unknown-prefix``,
+    ``chrome-decrypt-failed``, ``chrome-crypto-missing``).
+    """
+    if not _HAS_CRYPTO:
+        raise ChromeCookieError("chrome-crypto-missing")
     if blob.startswith(b"v20"):
-        raise ValueError("chrome-app-bound")
+        raise ChromeCookieError("chrome-app-bound")
     if not blob.startswith((b"v10", b"v11")):
-        raise ValueError("chrome-unknown-prefix")
-    try:
-        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-    except ImportError:
-        raise ChromeCookieError("chrome-crypto-missing") from None
+        raise ChromeCookieError("chrome-unknown-prefix")
     ciphertext = blob[3:]
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
     decryptor = Cipher(algorithms.AES(key), modes.CBC(_CHROME_CBC_IV)).decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     if not padded:
-        raise ValueError("chrome-decrypt-failed")
+        raise ChromeCookieError("chrome-decrypt-failed")
     pad = padded[-1]
     if pad < 1 or pad > 16 or padded[-pad:] != bytes([pad] * pad):
-        raise ValueError("chrome-decrypt-failed")
+        raise ChromeCookieError("chrome-decrypt-failed")
     plaintext = _strip_chrome_host_hash(padded[:-pad], host_key)
     try:
         return plaintext.decode("utf-8")
     except UnicodeDecodeError as exc:
-        raise ValueError("chrome-decrypt-failed") from exc
+        raise ChromeCookieError("chrome-decrypt-failed") from exc
 
 
 def _chrome_expires_ok(expires_utc: object, now: float) -> bool:
@@ -342,7 +372,7 @@ def load_chrome_grok_cookies() -> Optional[str]:
         raise
     except OSError as exc:
         if _is_tcc_error(exc):
-            raise ChromeCookieError("chrome-tcc-denied") from None
+            _raise_chrome_tcc()
         return None
 
     now = time.time()
@@ -365,9 +395,14 @@ def load_chrome_grok_cookies() -> Optional[str]:
                 ).fetchall()
         except OSError as exc:
             if _is_tcc_error(exc):
-                raise ChromeCookieError("chrome-tcc-denied") from None
+                _raise_chrome_tcc()
             continue
         except sqlite3.Error:
+            logger.debug(
+                "browser_cookies ▸ unreadable Chrome cookie DB (skip): %s",
+                source,
+                exc_info=True,
+            )
             continue
 
         pairs: list[tuple[str, str]] = []
@@ -380,14 +415,15 @@ def load_chrome_grok_cookies() -> Optional[str]:
                 key = _chrome_aes_key()
             try:
                 value = decrypt_chrome_cookie_value(key, bytes(blob), host_key=str(host_key or ""))
-            except ChromeCookieError:
-                raise
-            except ValueError as exc:
-                reason = str(exc) if str(exc).startswith("chrome-") else "chrome-decrypt-failed"
-                decrypt_reason = reason
+            except ChromeCookieError as exc:
+                if exc.reason in _HARD_CHROME_FAILURES:
+                    raise
+                # Soft failure: record the typed reason and try the next
+                # source database instead of aborting the whole import.
+                decrypt_reason = exc.reason
                 continue
-            except Exception:
-                raise ChromeCookieError("chrome-decrypt-failed") from None
+            except Exception as exc:
+                raise ChromeCookieError("chrome-decrypt-failed") from exc
             if value:
                 pairs.append((str(name), value))
         header = _cookie_header(iter(pairs))

--- a/quota_providers/grok.py
+++ b/quota_providers/grok.py
@@ -135,7 +135,9 @@ def _parse_grok_protobuf(raw: bytes) -> Optional[QuotaResult]:
 
     # Field map (decoded from a live capture, cross-checked against the
     # grok.com usage screen):
-    #   fn1 float          — Weekly Limit % used
+    #   fn1 float          — Weekly Limit % used (ABSENT = 0% used; the
+    #                        grok.com panel renders "0% utilizado" when the
+    #                        field is missing, e.g. free/unused accounts)
     #   fn4 / fn5 msg      — Weekly window start / reset (fn1 = epoch seconds)
     #   fn7 msg            — typed sub-quota: fn1 = kind, fn2 float = % used
     #                        (kind 2 = "Grok Build" on the usage screen)
@@ -206,6 +208,10 @@ def _parse_grok_protobuf(raw: bytes) -> Optional[QuotaResult]:
             return None
 
     windows: list[QuotaWindow] = []
+    if used_percent is None and reset_epoch is not None:
+        # Weekly window present but no usage field: the grok.com panel
+        # renders this as "0% utilizado" (free/unused accounts).
+        used_percent = 0.0
     if used_percent is not None or reset_epoch is not None:
         windows.append(
             QuotaWindow(label="Weekly", used_percent=used_percent, reset_at=_iso(reset_epoch))

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -11,8 +11,11 @@ import json
 import os
 import sqlite3
 import sys
+import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -31,6 +34,22 @@ except ImportError:  # pragma: no cover - environment-dependent
 _TEST_PASSWORD = "test-chrome-safe-storage"
 _FUTURE_EXPIRES = 20_000_000_000_000_000  # Chrome epoch, far future
 _EXPIRED_EXPIRES = 1
+
+
+@contextmanager
+def _temp_chrome_root() -> Iterator[Path]:
+    """Yield a throwaway ``<tmp>/Chrome`` user-data root."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "Chrome"
+        root.mkdir()
+        yield root
+
+
+@contextmanager
+def _temp_cookies_db() -> Iterator[Path]:
+    """Yield the path of a throwaway (empty, not-yet-created) cookies DB."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp) / "Cookies"
 
 
 def _pbkdf2_key(password: bytes) -> bytes:
@@ -140,20 +159,7 @@ class ChromeDiscoveryTests(unittest.TestCase):
         self.assertEqual(dirs[0].name, "Default")
 
     def _temp_chrome(self):
-        import tempfile
-
-        class _Ctx:
-            def __enter__(self_inner):
-                self_inner._tmp = tempfile.TemporaryDirectory()
-                root = Path(self_inner._tmp.name) / "Chrome"
-                root.mkdir()
-                return root
-
-            def __exit__(self_inner, *exc):
-                self_inner._tmp.cleanup()
-                return False
-
-        return _Ctx()
+        return _temp_chrome_root()
 
 
 @unittest.skipUnless(_HAS_CRYPTO, "cryptography is required for Chrome decrypt tests")
@@ -166,13 +172,12 @@ class ChromeDecryptTests(unittest.TestCase):
         self.assertEqual(decrypt_chrome_cookie_value(key, blob), "s3cret-value")
 
     def test_rejects_v20_prefix(self):
-        from quota_providers.browser_cookies import decrypt_chrome_cookie_value
+        from quota_providers.browser_cookies import ChromeCookieError, decrypt_chrome_cookie_value
 
         key = _pbkdf2_key(_TEST_PASSWORD.encode("utf-8"))
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(ChromeCookieError) as ctx:
             decrypt_chrome_cookie_value(key, b"v20" + b"\x00" * 32)
-        msg = str(ctx.exception).lower()
-        self.assertTrue("v20" in msg or "app-bound" in msg)
+        self.assertEqual(ctx.exception.reason, "chrome-app-bound")
 
     def test_strips_chrome127_host_hash_prefix(self):
         from quota_providers.browser_cookies import decrypt_chrome_cookie_value
@@ -301,18 +306,7 @@ class ChromeLoaderTests(unittest.TestCase):
         self.assertEqual(ctx.exception.reason, "chrome-tcc-denied")
 
     def _db(self):
-        import tempfile
-
-        class _Ctx:
-            def __enter__(self_inner):
-                self_inner._tmp = tempfile.TemporaryDirectory()
-                return Path(self_inner._tmp.name) / "Cookies"
-
-            def __exit__(self_inner, *exc):
-                self_inner._tmp.cleanup()
-                return False
-
-        return _Ctx()
+        return _temp_cookies_db()
 
 
 class GrokChromeWireTests(unittest.TestCase):

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -253,6 +253,41 @@ class GrokRestTests(unittest.TestCase):
             res = grok._fetch_grok_rest("cookie=1")
         self.assertEqual(res.unavailable_reason, "cloudflare-blocked")
 
+    def test_grpc_no_usage_field_means_zero_percent(self):
+        """Live capture from a free/unused account: the weekly window and
+        banked flag are present but the fn1 usage field is ABSENT — the
+        grok.com panel renders this as "0% utilizado", so the parser must
+        report 0.0 instead of hiding the number."""
+        import struct
+
+        from quota_providers import grok
+
+        def _vi(n: int) -> bytes:
+            out = bytearray()
+            while True:
+                b = n & 0x7F
+                n >>= 7
+                if n:
+                    out.append(b | 0x80)
+                else:
+                    out.append(b)
+                    return bytes(out)
+
+        sub = b"\x08" + _vi(1788109248)  # fn1 = weekly reset epoch
+        inner = b"\x2a" + _vi(len(sub)) + sub  # fn5 = weekly window (no fn1 %)
+        inner += b"\x58\x01"  # fn11 = reset banked
+        msg = b"\x0a" + _vi(len(inner)) + inner  # fn1 = response payload
+        raw = b"\x00" + struct.pack(">I", len(msg)) + msg
+
+        res = grok._parse_grok_protobuf(raw)
+        self.assertIsNotNone(res)
+        self.assertIsNone(res.unavailable_reason)
+        by_label = {w.label: w for w in res.windows}
+        self.assertIn("Weekly", by_label)
+        self.assertAlmostEqual(by_label["Weekly"].used_percent, 0.0, places=2)
+        self.assertIn("2026-08-30T17:00:48", by_label["Weekly"].reset_at)
+        self.assertTrue(any("Reset banked" in d for d in res.details))
+
     def test_optin_disabled_by_default(self):
         from quota_providers import grok
 


### PR DESCRIPTION
## Summary

Consolidated cleanup from a parallel 4-reviewer pass (reuse / quality / efficiency / altitude) over PR #2, applied after merge.

- `ChromeCookieError` now subclasses `ValueError`: the decrypt primitive raises typed failures directly; the loader drops the `str(exc).startswith("chrome-")` re-parse. Soft failures (app-bound / decrypt-failed / unknown-prefix) still degrade to the next profile DB via `.reason`; only `chrome-crypto-missing` hard-fails.
- Single `_raise_chrome_tcc()` helper replaces 6 copies of the TCC idiom.
- Unexpected decrypt crashes keep their traceback (`from exc` instead of `from None`).
- Unreadable cookie DBs are debug-logged before skip (repo convention from quota_cache.py).
- `cryptography` dependency probed once at import time instead of per cookie.
- Tests: two hand-rolled `_Ctx` classes → shared context managers; v20 test pins the typed contract (`.reason == chrome-app-bound`).
- README documents all six typed failure reasons.

## Testing

```
python tests/test_browser_cookies.py   # 17/17 OK
PYTHONPATH=. python tests/test_fetchers.py    # 14/14 OK
PYTHONPATH=. python tests/test_copilot.py     # OK
PYTHONPATH=. python tests/test_opencode_go.py # 16/16 OK
```

Live on macOS: Chrome → Keychain → AES decrypt → grok.com API returns Weekly window; installed-plugin refresh shows `grok · Weekly (reset Aug 30 18:00)` with no unavailable reason.