### PR TITLE
fix(widget): bind update-check cache to the installed stamp

### DIFF
--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -449,7 +449,10 @@ const REPO_API_LATEST =
 	"https://api.github.com/repos/rarf/hermes-quota-plugin/commits/master";
 
 // Compare the installed commit stamp against GitHub master. One cheap
-// request per hour, cached in storage; never blocks rendering.
+// request per hour, cached in storage; never blocks rendering. The cache
+// entry is bound to the stamp it was taken with (`seen`) — so installing
+// a new version invalidates it immediately instead of serving a stale
+// "update available" verdict for the rest of the hour.
 function useUpdateCheck() {
 	const [update, setUpdate] = useState(null);
 	useEffect(() => {
@@ -469,7 +472,9 @@ function useUpdateCheck() {
 				/* not stamped (older install) — skip check */
 			}
 			if (!installedSha || installedSha === "unknown") return;
-			// Throttle: at most one GitHub call per hour.
+			// Throttle: at most one GitHub call per hour. The cached verdict
+			// is only valid for the installed stamp it was taken with — a
+			// fresh install must re-check immediately.
 			try {
 				const prev = CTX.storage.get(CHECK_KEY);
 				if (prev) {
@@ -477,7 +482,8 @@ function useUpdateCheck() {
 					if (
 						p.at &&
 						Date.now() - p.at < ONE_HOUR &&
-						p.latest
+						p.latest &&
+						p.seen === installedSha
 					) {
 						if (p.latest !== installedSha) {
 							setUpdate({ latest: p.latest });
@@ -499,7 +505,11 @@ function useUpdateCheck() {
 				try {
 					CTX.storage.set(
 						CHECK_KEY,
-						JSON.stringify({ at: Date.now(), latest }),
+						JSON.stringify({
+							at: Date.now(),
+							latest,
+							seen: installedSha,
+						}),
 					);
 				} catch {
 					/* noop */

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: quota
-version: 2.3.0
+version: 2.3.1
 description: "Per-provider quota / rate-limit status via /quota command and desktop widget. Reads precomputed quota_cache.json so the widget never does network I/O. Cherry-pick providers in Settings. Nous Portal works on free accounts; Gemini detects tier via loadCodeAssist; Grok uses the REST rate-limits endpoint. Pane detail: clean or dense."
 author: rarf
 kind: standalone


### PR DESCRIPTION
## Problem

The widget's update self-check caches its GitHub verdict for one hour (`{at, latest}`). If you install a new version **during** that window, the cached `latest` no longer matches the new `installed_sha`, so the banner keeps claiming "Update available" for an up-to-date install until the hour expires. Hit in practice today after several same-day installs.

## Fix

Bind the cached verdict to the stamp it was taken with:

- store `seen: installedSha` alongside `{at, latest}`
- serve the cached verdict only when `p.seen === installedSha`

Installing a new version now invalidates the cache instantly → immediate fresh check, correct verdict. Older cache entries (without `seen`) simply fail the equality and trigger one fresh fetch — self-healing, no migration needed.

## Testing

- `node --check desktop/plugin.js` ✓ (CI Desktop widget syntax will confirm)
- version bump 2.3.0 → 2.3.1